### PR TITLE
Add formatSIRET, formatSIREN, formatVAT methods + tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ const re = {
   SIRET: /^\d{14}$/,
   SIREN: /^\d{9}$/,
   VAT: /^FR\d{11}$/,
+  formatSIRET: /^(\d{3})(\d{3})(\d{3})(\d{5})$/g,
+  formatSIREN: /(\d\d\d\B)/g,
+  formatVAT: /^([A-Z]{2})(\d{2})(\d{3})(\d{3})(\d{3})$/,
 };
 
 /**
@@ -112,10 +115,34 @@ function toVAT(value) {
   return `FR${key}${siren}`;
 }
 
+function formatSIRET(value) {
+  if (!isSIRET(value)) {
+    throw new Error('Not a valid SIRET');
+  }
+  return value.replace(re.formatSIRET, '$1 $2 $3 $4');
+}
+
+function formatSIREN(value) {
+  if (!isSIREN(value)) {
+    throw new Error('Not a valid SIREN');
+  }
+  return value.replace(re.formatSIREN, '$1 ');
+}
+
+function formatVAT(value) {
+  if (!isVAT(value)) {
+    throw new Error('Not a valid VAT number');
+  }
+  return value.replace(re.formatVAT, '$1 $2 $3 $4 $5');
+}
+
 module.exports = {
   isSIREN,
   isSIRET,
   isVAT,
   toSIREN,
   toVAT,
+  formatSIRET,
+  formatSIREN,
+  formatVAT,
 };

--- a/test/formatSIREN.js
+++ b/test/formatSIREN.js
@@ -1,0 +1,11 @@
+const lib = require('../index');
+
+[0, 1, true, false, {}, [], '81345471', '8134547171', 'FR42813454717', '81345471700014'].forEach((value) => {
+  test(`formatSIREN bad value ${JSON.stringify(value)}`, () => {
+    expect(() => lib.formatSIREN(value)).toThrow('Not a valid SIREN');
+  });
+});
+
+test(`format SIREN good values`, () => {
+  expect(['813454717', '803417153'].map(lib.formatSIREN)).toEqual(['813 454 717', '803 417 153']);
+});

--- a/test/formatSIRET.js
+++ b/test/formatSIRET.js
@@ -1,0 +1,11 @@
+const lib = require('../index');
+
+[0, 1, true, false, {}, [], '813454717', 'FR42813454717', '813454717000141', '181345471700014'].forEach((value) => {
+  test(`formatSIRET bad value ${JSON.stringify(value)}`, () => {
+    expect(() => lib.formatSIRET(value)).toThrow('Not a valid SIRET');
+  });
+});
+
+test(`format SIRET good values`, () => {
+  expect(['81345471700014', '80341715300035'].map(lib.formatSIRET)).toEqual(['813 454 717 00014', '803 417 153 00035']);
+});

--- a/test/formatVAT.js
+++ b/test/formatVAT.js
@@ -1,0 +1,11 @@
+const lib = require('../index');
+
+[0, 1, true, false, {}, [], '813454717', 'FR4281345471', 'FR428134547171'].forEach((value) => {
+  test(`bad value ${JSON.stringify(value)}`, () => {
+    expect(() => lib.formatVAT(value)).toThrow('Not a valid VAT number');
+  });
+});
+
+test(`format VAT good values`, () => {
+  expect(['FR42813454717', 'FR30803417153'].map(lib.formatVAT)).toEqual(['FR 42 813 454 717', 'FR 30 803 417 153']);
+});


### PR DESCRIPTION
Add the following methods:
- `formatSIRET`
- `formatSIREN`
- `formatVAT`

These methods internally use `isXXXX` to check if the input value is valid, and throw an error otherwise.

The regexps could probably be optimized, but I think this will do fine. Also, it might be interesting to have a `formatSIRETorSIREN` kind of method, because most programs accept both SIRET & SIREN from users.

I also added tests 😄 Feel free to give me some feedback if you'd like something done differently

Cheers