### PR TITLE
Improve format methods error handling & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,33 @@
 This library allows to check french VAT, SIRET and SIREN and to generate VAT or SIREN from SIRET, SIREN and VAT.
 
 ## Installation
+
 ```
 npm install vat-siren-siret --save
 ```
 
 ## Usage
+
 ```js
 const vss = require('vat-siren-siret');
 
 // Check string
-
-console.log( vss.isSIREN('813454717') );        // true
-console.log( vss.isSIRET('81345471700014') );   // true
-console.log( vss.isVAT('FR42813454717') );      // true
+console.log(vss.isSIREN('813454717')); // true
+console.log(vss.isSIRET('81345471700014')); // true
+console.log(vss.isVAT('FR42813454717')); // true
 
 // Generate french VAT
-console.log( vss.toVAT('813454717') );          // FR42813454717
-console.log( vss.toVAT('81345471700014') );     // FR42813454717
+console.log(vss.toVAT('813454717')); // FR42813454717
+console.log(vss.toVAT('81345471700014')); // FR42813454717
 
 // Generate SIREN
-console.log( vss.toSIREN('81345471700014') );   // 813454717
-console.log( vss.toSIREN('FR42813454717') );    // 813454717
+console.log(vss.toSIREN('81345471700014')); // 813454717
+console.log(vss.toSIREN('FR42813454717')); // 813454717
 
-
+// Format
+console.log(vss.formatSIREN('813454717')); // 813 454 717
+console.log(vss.formatSIRET('81345471700014')); // 813 454 717 00014
+console.log(vss.formatVAT('FR30803417153')); // FR 30 803 417 153
 ```
 
 ### isSIREN(value)
@@ -54,5 +58,18 @@ Return `value` if it already is a VAT.
 Generate the SIREN from a VAT or a SIRET and return a `string` or `false` as `boolean` when value is wrong.
 Return `value` if it already is a SIREN.
 
+## formatSIREN(value)
+
+If `value` is a valid SIREN, returns a properly formatted SIREN (eg. `552 100 554`). Otherwise, returns the value as is.
+
+## formatSIRET(value)
+
+If `value` is a valid SIRET, returns a properly formatted SIRET (eg. `732 829 320 00074`). Otherwise, returns the value as is.
+
+## formatVAT(value)
+
+If `value` is a valid VAT number, returns a properly formatted VAT number (eg. `FR 30 803 417 153`). Otherwise, returns the value as is.
+
 ## License
+
 [MIT](https://opensource.org/licenses/MIT)

--- a/index.js
+++ b/index.js
@@ -115,23 +115,38 @@ function toVAT(value) {
   return `FR${key}${siren}`;
 }
 
+/**
+ * Format (prettify) a SIRET
+ * @param {string} value
+ * @return {string}
+ */
 function formatSIRET(value) {
   if (!isSIRET(value)) {
-    throw new Error('Not a valid SIRET');
+    return value;
   }
   return value.replace(re.formatSIRET, '$1 $2 $3 $4');
 }
 
+/**
+ * Format (prettify) a SIREN
+ * @param {string} value
+ * @return {string}
+ */
 function formatSIREN(value) {
   if (!isSIREN(value)) {
-    throw new Error('Not a valid SIREN');
+    return value;
   }
   return value.replace(re.formatSIREN, '$1 ');
 }
 
+/**
+ * Format (prettify) a VAT
+ * @param {string} value
+ * @return {string}
+ */
 function formatVAT(value) {
   if (!isVAT(value)) {
-    throw new Error('Not a valid VAT number');
+    return value;
   }
   return value.replace(re.formatVAT, '$1 $2 $3 $4 $5');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vat-siren-siret",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Library to check or generate french VAT / SIRET / SIREN",
   "main": "index.js",
   "scripts": {

--- a/test/formatSIREN.js
+++ b/test/formatSIREN.js
@@ -2,7 +2,7 @@ const lib = require('../index');
 
 [0, 1, true, false, {}, [], '81345471', '8134547171', 'FR42813454717', '81345471700014'].forEach((value) => {
   test(`formatSIREN bad value ${JSON.stringify(value)}`, () => {
-    expect(() => lib.formatSIREN(value)).toThrow('Not a valid SIREN');
+    expect(() => lib.formatSIREN(value)).toBe(value);
   });
 });
 

--- a/test/formatSIREN.js
+++ b/test/formatSIREN.js
@@ -1,9 +1,8 @@
 const lib = require('../index');
 
-[0, 1, true, false, {}, [], '81345471', '8134547171', 'FR42813454717', '81345471700014'].forEach((value) => {
-  test(`formatSIREN bad value ${JSON.stringify(value)}`, () => {
-    expect(() => lib.formatSIREN(value)).toBe(value);
-  });
+test(`test SIREN bad values`, () => {
+  const badValues = [0, 1, true, false, {}, [], '81345471', '8134547171', 'FR42813454717', '81345471700014'];
+  expect(badValues.map(lib.formatSIREN)).toEqual(badValues);
 });
 
 test(`format SIREN good values`, () => {

--- a/test/formatSIRET.js
+++ b/test/formatSIRET.js
@@ -1,9 +1,8 @@
 const lib = require('../index');
 
-[0, 1, true, false, {}, [], '813454717', 'FR42813454717', '813454717000141', '181345471700014'].forEach((value) => {
-  test(`formatSIRET bad value ${JSON.stringify(value)}`, () => {
-    expect(() => lib.formatSIRET(value)).toBe(value);
-  });
+test(`formatSIRET bad values`, () => {
+  const badValues = [0, 1, true, false, {}, [], '813454717', 'FR42813454717', '813454717000141', '181345471700014'];
+  expect(badValues.map(lib.formatSIRET)).toEqual(badValues);
 });
 
 test(`format SIRET good values`, () => {

--- a/test/formatSIRET.js
+++ b/test/formatSIRET.js
@@ -2,7 +2,7 @@ const lib = require('../index');
 
 [0, 1, true, false, {}, [], '813454717', 'FR42813454717', '813454717000141', '181345471700014'].forEach((value) => {
   test(`formatSIRET bad value ${JSON.stringify(value)}`, () => {
-    expect(() => lib.formatSIRET(value)).toThrow('Not a valid SIRET');
+    expect(() => lib.formatSIRET(value)).toBe(value);
   });
 });
 

--- a/test/formatVAT.js
+++ b/test/formatVAT.js
@@ -1,9 +1,9 @@
 const lib = require('../index');
 
-[0, 1, true, false, {}, [], '813454717', 'FR4281345471', 'FR428134547171'].forEach((value) => {
-  test(`bad value ${JSON.stringify(value)}`, () => {
-    expect(() => lib.formatVAT(value)).toBe(value);
-  });
+
+test('format VAT bad values', () => {
+  const badValues = [0, 1, true, false, {}, [], '813454717', 'FR4281345471', 'FR428134547171'];
+  expect(badValues.map(lib.formatVAT)).toEqual(badValues);
 });
 
 test(`format VAT good values`, () => {

--- a/test/formatVAT.js
+++ b/test/formatVAT.js
@@ -2,7 +2,7 @@ const lib = require('../index');
 
 [0, 1, true, false, {}, [], '813454717', 'FR4281345471', 'FR428134547171'].forEach((value) => {
   test(`bad value ${JSON.stringify(value)}`, () => {
-    expect(() => lib.formatVAT(value)).toThrow('Not a valid VAT number');
+    expect(() => lib.formatVAT(value)).toBe(value);
   });
 });
 


### PR DESCRIPTION
# Improve format methods error handling & update README
- If the value is not valid, returns the value "as is" instead of throwing an error
- Add JSDoc on new methods
- Document the new methods in the README